### PR TITLE
Add HTTP Headers viewer

### DIFF
--- a/http-headers-viewer/Dockerfile
+++ b/http-headers-viewer/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.14
+
+COPY main.go /
+
+CMD ["go", "run", "/main.go"]

--- a/http-headers-viewer/Makefile
+++ b/http-headers-viewer/Makefile
@@ -1,0 +1,16 @@
+VERSION=0.1
+NAME=http-headers-viewer
+REMOTE=mirakl/$(NAME)
+
+default: build
+
+build:
+	docker build . -t $(NAME)
+
+push: build
+	docker tag $(NAME) $(REMOTE)
+	docker tag $(NAME) $(REMOTE):$(VERSION)
+	docker push $(REMOTE)
+
+run: build
+	docker run $(NAME)

--- a/http-headers-viewer/Readme.md
+++ b/http-headers-viewer/Readme.md
@@ -1,0 +1,18 @@
+## HTTP header viewer
+
+When configuring an application behind a reverse proxy, sometimes you need to check the HTTP headers passed to the application.
+
+This container prints all http headers in the response body.
+
+# Sample output : 
+
+    15:10 [~] $ curl http://localhost:8080
+    Accept: */*
+    User-Agent: curl/7.64.1
+
+# Usage : 
+
+Run docker image directly : `docker run mirakl/http-headers-viewer`
+
+Build & run : `make run`
+

--- a/http-headers-viewer/main.go
+++ b/http-headers-viewer/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		request.Header.Write(writer)
+	})
+
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This application is used to debug reverse proxy configurations, and
simply dumps all http headers in the response body